### PR TITLE
Add error classes for PoFile errors

### DIFF
--- a/lib/get_pomo.rb
+++ b/lib/get_pomo.rb
@@ -1,8 +1,13 @@
 require 'get_pomo/po_file'
+
 module GetPomo
   autoload :VERSION, "get_pomo/version"
-  
+
   extend self
+
+  class GetPomo::Error < StandardError; end
+  class GetPomo::InvalidString < GetPomo::Error; end
+  class GetPomo::InvalidMethod < GetPomo::Error; end
 
   # A message is unique if the combination of msgid and msgctxt is unique.
   # An emtpy msgctxt does not mean the same thing as no msgctxt.

--- a/lib/get_pomo/po_file.rb
+++ b/lib/get_pomo/po_file.rb
@@ -106,7 +106,6 @@ module GetPomo
     #msgid "hello" -> method call msgid + add string "hello"
     def parse_method_call(line)
       method, string = line.match(/^\s*([a-z0-9_\[\]]+)(.*)/)[1..2]
-      raise "no method found" unless method
       start_new_translation if %W(msgid msgctxt msgctxt).include? method and translation_complete?
       @last_method = method.to_sym
       add_string(string)
@@ -116,7 +115,7 @@ module GetPomo
     def add_string(string)
       string = string.strip
       return if string.empty?
-      raise "not string format: #{string.inspect} on line #{@line_number}" unless string =~ /^['"](.*)['"]$/
+      raise GetPomo::InvalidString, "Not a string format: #{string.inspect} on line #{@line_number}" unless string =~ /^['"](.*)['"]$/
       string_content = string[1..-2] #remove leading and trailing quotes from content
       @current_translation.add_text(string_content, :to=>@last_method)
     end

--- a/lib/get_pomo/translation.rb
+++ b/lib/get_pomo/translation.rb
@@ -12,10 +12,8 @@ module GetPomo
       elsif to.to_s =~ /^msgstr\[(\d)\]$/
         self.msgstr ||= []
         msgstr[$1.to_i] = msgstr[$1.to_i].to_s + text
-      elsif to.to_sym == :comment && text =~ OBSOLETE_REGEX
-        send("#{to}=",send(to).to_s+text)
       else
-        #simple form
+        raise GetPomo::InvalidMethod, "No method found for #{to}" unless self.respond_to?(to)
         send("#{to}=",send(to).to_s+text)
       end
     end

--- a/spec/pomo/po_file_spec.rb
+++ b/spec/pomo/po_file_spec.rb
@@ -133,13 +133,12 @@ describe GetPomo::PoFile do
     GetPomo::PoFile.parse(%Q(\n\n\n\n\n))
   end
 
+  it "raises when method is not found" do
+    expect{GetPomo::PoFile.parse(%Q(xxx "yyy"))}.to raise_error(GetPomo::InvalidMethod)
+  end
+
   it "shows line number for invalid strings" do
-    begin
-      GetPomo::PoFile.parse(%Q(\n\n\n\n\nmsgstr "))
-      flunk
-    rescue Exception => e
-      e.to_s.should =~ /line 5/
-    end
+    expect{GetPomo::PoFile.parse(%Q(\n\n\n\n\nmsgstr "))}.to raise_error(GetPomo::InvalidString)
   end
 
   describe :to_text do


### PR DESCRIPTION
RuntimeError doesn't really make sense. I added error classes to be more descriptive.
